### PR TITLE
Add tool support with Google search

### DIFF
--- a/Stud/stud.h
+++ b/Stud/stud.h
@@ -4,6 +4,8 @@
 #include <sampling.h>
 #include <mutex>
 #include <vector>
+#include <unordered_map>
+#include <string>
 #include <atomic>
 #pragma comment(lib, "llama.lib")
 #pragma comment(lib, "common.lib")
@@ -26,6 +28,9 @@ inline int _gaN = 0;
 inline int _gaW = 0;
 inline int _nPast = 0;
 inline int _nConsumed = 0;
+inline std::vector<common_chat_tool> _tools;
+inline std::unordered_map<std::string, char*(*)(const char*)> _toolHandlers;
+inline common_chat_format _chatFormat = COMMON_CHAT_FORMAT_CONTENT_ONLY;
 extern "C"{
 	EXPORT void BackendInit();
 	EXPORT void ResetChat(bool msgs);
@@ -38,7 +43,11 @@ extern "C"{
 	EXPORT void SetSystemPrompt(const char* prompt);
 	EXPORT void SetMessageAt(int index, const char* message);
 	EXPORT void RemoveMessageAt(int index);
-	EXPORT void RemoveMessagesStartingAt(int index);
-	EXPORT int Generate(unsigned int nPredict, bool callback);
-	EXPORT void StopGeneration();
+        EXPORT void RemoveMessagesStartingAt(int index);
+        EXPORT int Generate(unsigned int nPredict, bool callback);
+        EXPORT int GenerateWithTools(unsigned int nPredict, bool callback);
+        EXPORT char* GoogleSearch(const char* query);
+        EXPORT void AddTool(const char* name, const char* description, const char* parameters, char*(*handler)(const char* args));
+        EXPORT void ClearTools();
+        EXPORT void StopGeneration();
 }


### PR DESCRIPTION
## Summary
- add data structures for tools and track chat format
- wrap libcurl HTTP helper to perform Google searches
- support registering tools and clearing them
- rework tokenization to use chat templates and registered tools
- parse tool calls after generation with `GenerateWithTools`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840c72c9f088331b4459cc44e77b41b