### PR TITLE
Handle role in token callback

### DIFF
--- a/LM Stud/Form1.cs
+++ b/LM Stud/Form1.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Windows.Forms;
+using System.Runtime.InteropServices;
 using LMStud.Properties;
 namespace LMStud{
 	internal partial class Form1 : Form{
@@ -224,8 +225,8 @@ namespace LMStud{
 				cm.Width = panelChat.ClientSize.Width;
 				NativeMethods.AddMessage(true, msg);
 			}
-			_cntAssMsg = AddMessage(false, "");
-			NativeMethods.SendMessage(_this.panelChat.Handle, NativeMethods.WM_VSCROLL, (IntPtr)NativeMethods.SB_BOTTOM, IntPtr.Zero);
+                        _cntAssMsg = null;
+                        NativeMethods.SendMessage(_this.panelChat.Handle, NativeMethods.WM_VSCROLL, (IntPtr)NativeMethods.SB_BOTTOM, IntPtr.Zero);
 			foreach(var message in _chatMessages) message.Generating = true;
 			textInput.Text = "";
 			_tts.SpeakAsyncCancelAll();
@@ -262,44 +263,50 @@ namespace LMStud{
 			for(var i = 0; i < sb.Length - 1; i++) if((sb[i] == '.' || sb[i] == '!' || sb[i] == '?') && char.IsWhiteSpace(sb[i + 1])) return i;
 			return -1;
 		}
-		private static unsafe void TokenCallback(byte* strPtr, int strLen, int tokens, int tokensTotal, double ftTime){
-			var tokenStr = Encoding.UTF8.GetString(strPtr, strLen);
-			if(tokens == 0){
-				try{
-					_this.Invoke(new MethodInvoker(() => {
-						var cm = _this.AddMessage(false, tokenStr);
-						cm.SetRoleText("Tool");
-						cm.Width -= 1;//Workaround for resize issue
-						cm.Width = _this.panelChat.ClientSize.Width;
-						_this._cntAssMsg = _this.AddMessage(false, "");
-						_this.labelTokens.Text = tokensTotal + "/" + _this._cntCtxMax + " Tokens";
-						NativeMethods.SendMessage(_this.panelChat.Handle, NativeMethods.WM_VSCROLL, (IntPtr)NativeMethods.SB_BOTTOM, IntPtr.Zero);
-					}));
-				} catch(ObjectDisposedException){}
-				return;
-			}
-			_this._msgTokenCount += tokens;
-			var elapsed = _this._swRate.Elapsed.TotalSeconds;
-			if(elapsed >= 1.0) _this._swRate.Restart();
-			var renderToken = !_this._rendering;
-			try{
-				_this.BeginInvoke((MethodInvoker)(() => {
-					try{
-						_this._rendering = true;
-						if(_this._first){
-							_this.labelPreGen.Text = "First token time: " + ftTime + " s";
-							_this._first = false;
-						}
-						if(elapsed >= 1.0){
-							var callsPerSecond = _this._msgTokenCount/elapsed;
-							_this.labelTPS.Text = $"{callsPerSecond:F2} Tok/s";
-							_this._msgTokenCount = 0;
-						}
-						var lastThink = _this._cntAssMsg.checkThink.Checked;
-						_this._cntAssMsg.AppendText(tokenStr, renderToken);
-						if(_this._speak && !_this._cntAssMsg.checkThink.Checked && !lastThink && !string.IsNullOrWhiteSpace(tokenStr)){
-							foreach(var ch in tokenStr.Where(ch => ch != '`' && ch != '*' && ch != '_' && ch != '#')) _this._speechBuffer.Append(ch);
-							int idx;
+                private static unsafe void TokenCallback(byte* strPtr, int strLen, int tokens, int tokensTotal, double ftTime, IntPtr rolePtr){
+                        var tokenStr = Encoding.UTF8.GetString(strPtr, strLen);
+                        var role = Marshal.PtrToStringUTF8(rolePtr) ?? string.Empty;
+                        if(role == "tool"){
+                                try{
+                                        _this.Invoke(new MethodInvoker(() => {
+                                                var cm = _this.AddMessage(false, tokenStr);
+                                                cm.SetRoleText("Tool");
+                                                cm.Width -= 1;//Workaround for resize issue
+                                                cm.Width = _this.panelChat.ClientSize.Width;
+                                                _this._cntAssMsg = null;
+                                                _this.labelTokens.Text = tokensTotal + "/" + _this._cntCtxMax + " Tokens";
+                                                NativeMethods.SendMessage(_this.panelChat.Handle, NativeMethods.WM_VSCROLL, (IntPtr)NativeMethods.SB_BOTTOM, IntPtr.Zero);
+                                        }));
+                                } catch(ObjectDisposedException){}
+                                return;
+                        }
+                        _this._msgTokenCount += tokens;
+                        var elapsed = _this._swRate.Elapsed.TotalSeconds;
+                        if(elapsed >= 1.0) _this._swRate.Restart();
+                        var renderToken = !_this._rendering;
+                        try{
+                                _this.BeginInvoke((MethodInvoker)(() => {
+                                        try{
+                                                _this._rendering = true;
+                                                if(_this._first){
+                                                        _this.labelPreGen.Text = "First token time: " + ftTime + " s";
+                                                        _this._first = false;
+                                                }
+                                                if(elapsed >= 1.0){
+                                                        var callsPerSecond = _this._msgTokenCount/elapsed;
+                                                        _this.labelTPS.Text = $"{callsPerSecond:F2} Tok/s";
+                                                        _this._msgTokenCount = 0;
+                                                }
+                                                if(_this._cntAssMsg == null){
+                                                        _this._cntAssMsg = _this.AddMessage(false, "");
+                                                        _this._cntAssMsg.Width -= 1;//Workaround for resize issue
+                                                        _this._cntAssMsg.Width = _this.panelChat.ClientSize.Width;
+                                                }
+                                                var lastThink = _this._cntAssMsg.checkThink.Checked;
+                                                _this._cntAssMsg.AppendText(tokenStr, renderToken);
+                                                if(_this._speak && !_this._cntAssMsg.checkThink.Checked && !lastThink && !string.IsNullOrWhiteSpace(tokenStr)){
+                                                        foreach(var ch in tokenStr.Where(ch => ch != '`' && ch != '*' && ch != '_' && ch != '#')) _this._speechBuffer.Append(ch);
+                                                        int idx;
 							while((idx = FindSentenceEnd(_this._speechBuffer)) >= 0){
 								var sentence = _this._speechBuffer.ToString(0, idx + 1).Trim();
 								if(!string.IsNullOrWhiteSpace(sentence)) _this._tts.SpeakAsync(sentence);

--- a/LM Stud/NativeMethods.cs
+++ b/LM Stud/NativeMethods.cs
@@ -16,8 +16,8 @@ namespace LMStud{
 			Mirror = 4,
 			Count
 		}
-		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-		public unsafe delegate void TokenCallback(byte* strPtr, int strLen, int tokens, int tokensTotal, double ftTime);
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public unsafe delegate void TokenCallback(byte* strPtr, int strLen, int tokens, int tokensTotal, double ftTime, IntPtr rolePtr);
 		[DllImport(DLLName, CallingConvention = CallingConvention.Cdecl)]
 		public static extern void BackendInit();
 		[DllImport(DLLName, CallingConvention = CallingConvention.Cdecl)]

--- a/Stud/stud.cpp
+++ b/Stud/stud.cpp
@@ -213,14 +213,14 @@ int Generate(const unsigned int nPredict, const bool callback){
 			if(ftTime==0.0) ftTime = std::chrono::duration<double, std::ratio<1, 1>>(hr_clock::now()-prepStart).count();
 			if(!tokenStr.empty()){
 				assMsg<<tokenStr;
-				if(cb&&callback) cb(tokenStr.c_str(), static_cast<int>(tokenStr.length()), 1, static_cast<int>(_tokens.size()+i), ftTime);
+                                if(cb&&callback) cb(tokenStr.c_str(), static_cast<int>(tokenStr.length()), 1, static_cast<int>(_tokens.size()+i), ftTime, "assistant");
 			}
 			if(llama_vocab_is_eog(_vocab, id)) break;
 		}
 		embd.clear();
 	}
-	AddMessage(false, assMsg.str().c_str());
-	if(cb&&!callback) cb(assMsg.str().c_str(), assMsg.str().length(), i, static_cast<int>(_tokens.size()), ftTime);
+        AddMessage(false, assMsg.str().c_str());
+        if(cb&&!callback) cb(assMsg.str().c_str(), assMsg.str().length(), i, static_cast<int>(_tokens.size()), ftTime, "assistant");
 	return i;
 }
 int GenerateWithTools(const unsigned int nPredict, const bool callback){
@@ -239,7 +239,7 @@ int GenerateWithTools(const unsigned int nPredict, const bool callback){
 				const auto result = it->second(tc.arguments.c_str());
 				std::string resultStr = result ? result : "";
 				AddMessage(std::string("tool"), resultStr);
-				if(cb&&callback) cb(resultStr.c_str(), static_cast<int>(resultStr.length()), 0, static_cast<int>(_tokens.size()), 0);
+                                if(cb&&callback) cb(resultStr.c_str(), static_cast<int>(resultStr.length()), 0, static_cast<int>(_tokens.size()), 0, "tool");
 				if(result){
 					toolCalled = true;
 				}

--- a/Stud/stud.h
+++ b/Stud/stud.h
@@ -21,7 +21,7 @@ inline std::vector<llama_token> _tokens;
 inline std::vector<common_chat_msg> _chatMsgs;
 inline std::atomic_bool _stop{false};
 inline common_chat_templates_ptr _chatTemplates;
-using TokenCallbackFn = void(*)(const char* token, int strLen, int tokens, int tokensTotal, double ftTime);
+using TokenCallbackFn = void(*)(const char* token, int strLen, int tokens, int tokensTotal, double ftTime, const char* role);
 inline TokenCallbackFn _tokenCb = nullptr;
 inline int _nConsumed = 0;
 inline std::vector<common_chat_tool> _tools;


### PR DESCRIPTION
## Summary
- handle a `role` value in token callbacks
- create assistant messages lazily in `TokenCallback`
- send role info from C++ backend

## Testing
- `dotnet build 'LM Stud/LM Stud.csproj' -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684371806d4883318f1599c676153e32