### PR TITLE
Handle role in token callback

### DIFF
--- a/LM Stud/NativeMethods.cs
+++ b/LM Stud/NativeMethods.cs
@@ -16,8 +16,8 @@ namespace LMStud{
 			Mirror = 4,
 			Count
 		}
-		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-		public unsafe delegate void TokenCallback(byte* strPtr, int strLen, int tokens, int tokensTotal, double ftTime);
+                [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+                public unsafe delegate void TokenCallback(byte* strPtr, int strLen, int tokens, int tokensTotal, double ftTime, byte* rolePtr, int roleLen);
 		[DllImport(DLLName, CallingConvention = CallingConvention.Cdecl)]
 		public static extern void BackendInit();
 		[DllImport(DLLName, CallingConvention = CallingConvention.Cdecl)]

--- a/Stud/stud.cpp
+++ b/Stud/stud.cpp
@@ -213,14 +213,14 @@ int Generate(const unsigned int nPredict, const bool callback){
 			if(ftTime==0.0) ftTime = std::chrono::duration<double, std::ratio<1, 1>>(hr_clock::now()-prepStart).count();
 			if(!tokenStr.empty()){
 				assMsg<<tokenStr;
-				if(cb&&callback) cb(tokenStr.c_str(), static_cast<int>(tokenStr.length()), 1, static_cast<int>(_tokens.size()+i), ftTime);
+                                if(cb&&callback) cb(tokenStr.c_str(), static_cast<int>(tokenStr.length()), 1, static_cast<int>(_tokens.size()+i), ftTime, "assistant", 8);
 			}
 			if(llama_vocab_is_eog(_vocab, id)) break;
 		}
 		embd.clear();
 	}
-	AddMessage(false, assMsg.str().c_str());
-	if(cb&&!callback) cb(assMsg.str().c_str(), assMsg.str().length(), i, static_cast<int>(_tokens.size()), ftTime);
+        AddMessage(false, assMsg.str().c_str());
+        if(cb&&!callback) cb(assMsg.str().c_str(), assMsg.str().length(), i, static_cast<int>(_tokens.size()), ftTime, "assistant", 8);
 	return i;
 }
 int GenerateWithTools(const unsigned int nPredict, const bool callback){
@@ -239,7 +239,7 @@ int GenerateWithTools(const unsigned int nPredict, const bool callback){
 				const auto result = it->second(tc.arguments.c_str());
 				std::string resultStr = result ? result : "";
 				AddMessage(std::string("tool"), resultStr);
-				if(cb&&callback) cb(resultStr.c_str(), static_cast<int>(resultStr.length()), 0, static_cast<int>(_tokens.size()), 0);
+                                if(cb&&callback) cb(resultStr.c_str(), static_cast<int>(resultStr.length()), 0, static_cast<int>(_tokens.size()), 0, "tool", 4);
 				if(result){
 					toolCalled = true;
 				}

--- a/Stud/stud.h
+++ b/Stud/stud.h
@@ -21,7 +21,7 @@ inline std::vector<llama_token> _tokens;
 inline std::vector<common_chat_msg> _chatMsgs;
 inline std::atomic_bool _stop{false};
 inline common_chat_templates_ptr _chatTemplates;
-using TokenCallbackFn = void(*)(const char* token, int strLen, int tokens, int tokensTotal, double ftTime);
+using TokenCallbackFn = void(*)(const char* token, int strLen, int tokens, int tokensTotal, double ftTime, const char* role, int roleLen);
 inline TokenCallbackFn _tokenCb = nullptr;
 inline int _nConsumed = 0;
 inline std::vector<common_chat_tool> _tools;


### PR DESCRIPTION
## Summary
- handle a `role` value in token callbacks
- create assistant messages lazily in `TokenCallback`
- send role info from C++ backend
- remove PtrToStringUTF8 usage for .NET 4.8

## Testing
- `dotnet build 'LM Stud/LM Stud.csproj' -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684371806d4883318f1599c676153e32