### PR TITLE
Add web page caching and browsing tools

### DIFF
--- a/LM Stud/Form1.Tools.cs
+++ b/LM Stud/Form1.Tools.cs
@@ -1,16 +1,32 @@
 ﻿using System;
 namespace LMStud{
 	internal partial class Form1{
-		private NativeMethods.ToolHandler _googleHandler;
-		private static IntPtr GoogleSearchHandler(string args){return NativeMethods.GoogleSearch(args);}
-		private void RegisterTools(){
-			NativeMethods.ClearTools();
-			_googleHandler = GoogleSearchHandler;
-			if(_googleSearchEnable) NativeMethods.AddTool("google_search", "Search Google and return the top results", "{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\"}},\"required\":[\"query\"]}", _googleHandler);
-		}
-		private void ClearRegisteredTools(){
-			NativeMethods.ClearTools();
-			_googleHandler = null;
-		}
-	}
+                private NativeMethods.ToolHandler _googleHandler;
+                private NativeMethods.ToolHandler _fetchPageHandler;
+                private NativeMethods.ToolHandler _browseCacheHandler;
+                private NativeMethods.ToolHandler _getSectionHandler;
+                private static IntPtr GoogleSearchHandler(string args){return NativeMethods.GoogleSearch(args);}
+                private static IntPtr FetchPageHandler(string args){return NativeMethods.FetchWebpage(args);}
+                private static IntPtr BrowseCacheHandler(string args){return NativeMethods.BrowseWebCache(args);}
+                private static IntPtr GetSectionHandler(string args){return NativeMethods.GetWebSection(args);}
+                private void RegisterTools(){
+                        NativeMethods.ClearTools();
+                        _googleHandler = GoogleSearchHandler;
+                        _fetchPageHandler = FetchPageHandler;
+                        _browseCacheHandler = BrowseCacheHandler;
+                        _getSectionHandler = GetSectionHandler;
+                        if(_googleSearchEnable) NativeMethods.AddTool("google_search", "Search Google and return the top results", "{\"type\":\"object\",\"properties\":{\"query\":{\"type\":\"string\"}},\"required\":[\"query\"]}", _googleHandler);
+                        NativeMethods.AddTool("fetch_webpage", "Fetch a webpage and cache its sections", "{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"}},\"required\":[\"url\"]}", _fetchPageHandler);
+                        NativeMethods.AddTool("browse_web_cache", "List cached sections for a webpage", "{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"}},\"required\":[\"url\"]}", _browseCacheHandler);
+                        NativeMethods.AddTool("fetch_web_section", "Get text from a cached section", "{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"id\":{\"type\":\"integer\"}},\"required\":[\"url\",\"id\"]}", _getSectionHandler);
+                }
+                private void ClearRegisteredTools(){
+                        NativeMethods.ClearTools();
+                        NativeMethods.ClearWebCache();
+                        _googleHandler = null;
+                        _fetchPageHandler = null;
+                        _browseCacheHandler = null;
+                        _getSectionHandler = null;
+                }
+        }
 }

--- a/LM Stud/NativeMethods.cs
+++ b/LM Stud/NativeMethods.cs
@@ -63,9 +63,17 @@ namespace LMStud{
 		[DllImport(DLLName, CallingConvention = CallingConvention.Cdecl)]
 		public static extern void ClearTools();
 		[DllImport(DLLName, CallingConvention = CallingConvention.Cdecl)]
-		public static extern void StopGeneration();
-		[DllImport(DLLName, CallingConvention = CallingConvention.Cdecl)]
-		public static extern unsafe void ConvertMarkdownToRtf([MarshalAs(UnmanagedType.LPUTF8Str)] string markdown, ref byte* rtfOut, ref int rtfLen);
+                public static extern void StopGeneration();
+                [DllImport(DLLName, CallingConvention = CallingConvention.Cdecl)]
+                public static extern IntPtr FetchWebpage([MarshalAs(UnmanagedType.LPUTF8Str)] string args);
+                [DllImport(DLLName, CallingConvention = CallingConvention.Cdecl)]
+                public static extern IntPtr BrowseWebCache([MarshalAs(UnmanagedType.LPUTF8Str)] string args);
+                [DllImport(DLLName, CallingConvention = CallingConvention.Cdecl)]
+                public static extern IntPtr GetWebSection([MarshalAs(UnmanagedType.LPUTF8Str)] string args);
+                [DllImport(DLLName, CallingConvention = CallingConvention.Cdecl)]
+                public static extern void ClearWebCache();
+                [DllImport(DLLName, CallingConvention = CallingConvention.Cdecl)]
+                public static extern unsafe void ConvertMarkdownToRtf([MarshalAs(UnmanagedType.LPUTF8Str)] string markdown, ref byte* rtfOut, ref int rtfLen);
 		[DllImport(DLLName, CallingConvention = CallingConvention.Cdecl)]
 		public static extern void SetWhisperCallback(WhisperCallback cb);
 		[DllImport(DLLName, CallingConvention = CallingConvention.Cdecl)]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This project was born out of frustration with slow bloated embedded web-based GU
 - Minimal resource usage compared to embedded web GUIs
 - NEW! Huggingface model search and download!
 - EVEN NEWER! Voice prompting with Whisper.cpp and TTS!
+- Google search and webpage browsing tools for your models
 
 (Out of date screenshot but you get the idea)
 ![LM Stud Chat Interface](./screenshots/LMStud_Chat.png)

--- a/Stud/stud.h
+++ b/Stud/stud.h
@@ -49,4 +49,8 @@ extern "C"{
     EXPORT void AddTool(const char* name, const char* description, const char* parameters, char*(*handler)(const char* args));
     EXPORT void ClearTools();
     EXPORT void StopGeneration();
+    EXPORT const char* FetchWebpage(const char* argsJson);
+    EXPORT const char* BrowseWebCache(const char* argsJson);
+    EXPORT const char* GetWebSection(const char* argsJson);
+    EXPORT void ClearWebCache();
 }


### PR DESCRIPTION
## Summary
- implement cached web browsing features in C++ backend
- expose new backend functions to C# via NativeMethods
- register `fetch_webpage`, `browse_web_cache`, and `fetch_web_section` tools
- clear web cache when tools are cleared
- update README with mention of new tools

## Testing
- `g++ -std=c++17 -c Stud/stud.cpp -IStud -o /tmp/stud.o` *(fails: llama.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68446c391b5883319adddd4bd823c3e2